### PR TITLE
fix broken dasherize function

### DIFF
--- a/root/package.json
+++ b/root/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "<%= S(name).dasherize() %>",
+  "name": "<%= S(name).dasherize().value() %>",
   "description": "<%= description %>",
   "dependencies": {
     "autoprefixer-stylus": "0.5.x",


### PR DESCRIPTION
this fixes and issue when [sprout](http://github.com/carrot/sprout) migrated from `string.js` to `underscore.string`