### PR TITLE
bump autoprefixer, changed :markdown to :marked, add js-tranformer-marked as dependency

### DIFF
--- a/root/package.json
+++ b/root/package.json
@@ -2,12 +2,13 @@
   "name": "<%= S(name).dasherize().value() %>",
   "description": "<%= description %>",
   "dependencies": {
-    "autoprefixer-stylus": "0.6.x",
+    "autoprefixer-stylus": "0.7.x",
     "axis": "0.4.x",
     "coffee-script": "1.9.x",
     "css-pipeline": "0.2.x",
     "jade": "1.x",
     "js-pipeline": "0.2.x",
+    "jstransformer-marked": "0.0.x",
     "marked": "0.3.x",
     "rupture": "0.6.x",
     "stylus": "0.51.x"

--- a/root/views/index.jade
+++ b/root/views/index.jade
@@ -2,5 +2,5 @@ extends layout
 
 block content
   h3 Welcome to roots!
-  :markdown
+  :marked
     Find tutorials and documentation at http://roots.cx : )


### PR DESCRIPTION
I believe this should fix 2 warning issues, as noted here:
https://github.com/jenius/roots/issues/651

I'm not exactly sure how to test this one, but this fixed stuff for me in other roots builds.
