### PR TITLE
set the default axis image directory to the default image directory

### DIFF
--- a/root/assets/css/_settings.styl
+++ b/root/assets/css/_settings.styl
@@ -62,7 +62,7 @@ $default-color = $blue
 $highlight-color = $blue
 
 // Custom image base path for axis mixins
-$img-path = ''
+$img-path = '/img/'
 
 // Ligatures
 $ligatures = false


### PR DESCRIPTION
This will just allow axis image mixins to work right away without paths.